### PR TITLE
Functionality to check for Thirteen Orphans

### DIFF
--- a/src/ai_thirteen_orphan.js
+++ b/src/ai_thirteen_orphan.js
@@ -13,7 +13,6 @@ var thirteen_orphan_set = "19m19p19s1234567z";
 var max_missing_orphan_count = 2; // If an orphan has been discarded more than this time (and is not in hand), we don't go for thirteen orphan.
 // Ie. 'Red Dragon' is not in hand, but been discarded 3-times on field. We stop going for thirteen orphan.
 
-
 // Used at the start of a match to see if we can go for thirteen orphansm
 function startCanDoThirteenOrphan(){
     var ownTerminalHonors = getAllTerminalHonorFromHand(ownHand)
@@ -74,6 +73,28 @@ function canDoThirteenOrphan(){
     }
 
     return true;
+}
+
+// Returns a Tile[], all possible discards for thirteen orphan strategy.
+// TODO: With efficieny/defense in mind, if we want it to output a single Tile object instead.
+function findPossibleDiscards(){
+    var ownTerminalHonors = getAllTerminalHonorFromHand(ownHand)
+    var uniqueTerminalHonors = ownTerminalHonors.filter(function(t, i) {
+        return ownTerminalHonors.indexOf(t) == i;
+    });
+
+    var handClone = ownHand;
+    for (var i = 0; i < uniqueTerminalHonors.length; ++i){
+        // Remove any first occurance of the terminal/honors from the hand.
+        // (Aka, we don't want those to be thrown)
+        var firstOccurance = handClone.findIndex((t) => t == uniqueTerminalHonors[i]);
+        if (firstOccurance >= 0){
+            handClone.splice(firstOccurance, 1);
+        }
+    }
+
+    // Return the things to be thrown from hand.
+    return handClone;
 }
 
 // Return all orphan discards

--- a/src/ai_thirteen_orphan.js
+++ b/src/ai_thirteen_orphan.js
@@ -1,0 +1,121 @@
+//################################
+// AI Thirteen Orphan
+// AI to handle Thirteen Orphan strategy.
+//
+// TODO: Merge with ai_offense (?)
+// (Some may have to be merged into util.js instead?)
+//
+// TODO: Actual implementation for the AI to use it.
+//################################
+
+// PARAMETERS
+var thirteen_orphan_set = "19m19p19s1234567z";
+var max_missing_orphan_count = 2; // If an orphan has been discarded more than this time (and is not in hand), we don't go for thirteen orphan.
+// Ie. 'Red Dragon' is not in hand, but been discarded 3-times on field. We stop going for thirteen orphan.
+
+
+// Used at the start of a match to see if we can go for thirteen orphansm
+function startCanDoThirteenOrphan(){
+    var ownTerminalHonors = getAllTerminalHonorFromHand(ownHand)
+
+    // Automatically fails if below min-required length.
+    // (Probably can remove this check, as checking after filtering uniques shouldn't take too long either.)
+    if (ownTerminalHonors.length < THIRTEEN_ORPHANS){
+        return false;
+    }
+
+    // Filter out all duplicate terminal/honors
+    var uniqueTerminalHonors = ownTerminalHonors.filter(function(t, i) {
+        return ownTerminalHonors.indexOf(t) == i;
+    });
+
+    // Fails if we do not have enough unique orphans.
+    if (uniqueTerminalHonors.length < THIRTEEN_ORPHANS){
+        return false;
+    }
+
+    return true;
+}
+
+// Used during the match to see if its still viable to go for thirteen orphans.
+// TODO: Test Cases
+function canDoThirteenOrphan(){
+
+    var ownTerminalHonors = getAllTerminalHonorFromHand(ownHand)
+    // Filter out all duplicate terminal/honors
+    var uniqueTerminalHonors = ownTerminalHonors.filter(function(t, i) {
+        return ownTerminalHonors.indexOf(t) == i;
+    });
+
+    // Get list of missing orphans.
+    var thirteenOrphanTiles = getTilesFromString(thirteen_orphan_set);
+    var missingOrphans = thirteenOrphanTiles.filter(function(t) {
+        return !uniqueTerminalHonors.includes(t);
+      });
+
+    // TODO: Should we check for our own discards, to see if we had discarded an orphan we need? (furiten check)
+    // Probably reduntant as we would ideally never discard our own needed tiles. (?)
+
+    // Check if there are enough required orphans in the pool.
+    // TODO: Possible optimization?
+    var allOrphansDiscards = getAllDiscardsWithOrphans();
+    for (var i = 0; i < missingOrphans.length; ++i){
+        var discardCount = 0;
+        for (var n = 0; n < allOrphansDiscards.length; ++n){
+            if (allOrphansDiscards[n] == missingOrphans[i]){
+                ++discardCount;
+            }
+
+            // Too many of a needed orphan was discarded; No thirteen orphans.
+            if (discardCount > max_missing_orphan_count){
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+// Return all orphan discards
+// TODO: Possible optimization?
+function getAllDiscardsWithOrphans(){
+    var allOrphansDiscards = [];
+
+    for (var i = 0; i < discards.length; ++i){
+        for (var n = 0; n < discards[i].length; ++n){
+
+            if (isTerminalOrHonor(discards[i][n])){
+                allOrphansDiscards.push(discards[i][n]);
+            }
+        }
+    }
+
+    return allOrphansDiscards;
+}
+
+// Returns Tile[], where all is terminal/honors.
+function getAllTerminalHonorFromHand(hand){
+    var allTerminalHonor = [];
+    for (var i = 0; i < hand.length; ++i) { 
+        if (isTerminalOrHonor(hand[i])){
+            allTerminalHonor.push(hand[i]);
+        }
+    }
+    return allTerminalHonor;
+}
+
+
+
+function isTerminalOrHonor(tile){
+    // Honor tiles
+    if (tile.type == 3){
+        return true;
+    }
+
+    // 1 or 9.
+    if (tile.index == 1 || tile.index == 9){
+        return true;
+    }
+
+    return false;
+}

--- a/src/parameters.js
+++ b/src/parameters.js
@@ -38,7 +38,8 @@ var run = false; //Is the bot running
 const STRATEGIES = { //ENUM of strategies
 	GENERAL: 'General',
 	CHIITOITSU: 'Chiitoitsu',
-	FOLD: 'Fold'
+	FOLD: 'Fold',
+	THIRTEEN_ORPHANS: 'Thirteen_Orphans'
 }
 var strategy = STRATEGIES.GENERAL; //Current strategy
 var strategyAllowsCalls = true; //Does the current strategy allow calls?

--- a/test/test.js
+++ b/test/test.js
@@ -439,7 +439,6 @@ function runTestcase() {
 
 			expected = ["3m", "7p"];
 			break;
-
 		default:
 			testsRunning = false;
 			return;


### PR DESCRIPTION
Added Functions to assist in checking for Thirteen Orphans. I have yet to implemented it into the current AI, nor proper test-cases for it yet.

All functions are in `ai_thirteen_orphan.js`.
The three helper-functions are:

- `startCanDoThirteenOrphan() : bool` _Check if we can go for a thirteen orphan at the start._
- `canDoThirteenOrphan() : bool` _Check if we still can go for a thirteen orphan during the game. (In case of too many discards on a needed orphan)._
- `findPossibleDiscards() : Tile[]` _Helps to see what are the possible discards during the strategy._

### **TODOs**

- **Proper Test Cases.** So far I was only testing it via messy code, which isn't part of this pull-request.
- **Optimization**. Look for possible optimizations for better execution-speed.
- **Actual Implementation**. Actually implement it into AlphaJong.