### PR TITLE
fix Chanta and Junchan yaku miscalculation

### DIFF
--- a/src/yaku.js
+++ b/src/yaku.js
@@ -310,7 +310,8 @@ function getDaisangen(hand) {
 
 //Chanta
 function getChanta(triplets, sequences, pairs) {
-	if ((triplets.concat(pairs)).filter(tile => tile.type == 3 || tile.index == 1 || tile.index == 9).length +
+	if ((sequences.filter(tile => tile.index == 1 || tile.index == 9).length * 3) == sequences.length &&
+		(triplets.concat(pairs)).filter(tile => tile.type == 3 || tile.index == 1 || tile.index == 9).length +
 		(sequences.filter(tile => tile.index == 1 || tile.index == 9).length * 3) >= 13) {
 		return { open: 1, closed: 2 };
 	}
@@ -327,7 +328,8 @@ function getHonrou(triplets) {
 
 //Junchan
 function getJunchan(triplets, sequences, pairs) {
-	if ((triplets.concat(pairs)).filter(tile => tile.type != 3 && (tile.index == 1 || tile.index == 9)).length +
+	if ((sequences.filter(tile => tile.index == 1 || tile.index == 9).length * 3) == sequences.length &&
+		(triplets.concat(pairs)).filter(tile => tile.type != 3 && (tile.index == 1 || tile.index == 9)).length +
 		(sequences.filter(tile => tile.index == 1 || tile.index == 9).length * 3) >= 13) {
 		return { open: 1, closed: 1 }; // - Added to Chanta
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -668,6 +668,19 @@ async function runCallTestcase() {
 			}
 			break;
 
+		case 7:
+			logTestcase("Test Call with Chanta Yaku");
+			ownHand = getTilesFromString("3406m237899p789s");
+			isClosed = true;
+			updateAvailableTiles();
+			testCallTile = { index: 9, type: 0, dora: false, doraValue: 0 };
+			var callResult = await callTriple(["7p|8p","9p|9p"], 0);
+			expected = ["9p"];
+			if (callResult) { //Should decline
+				expected = ["0z"];
+			}
+			break;
+
 		default:
 			nextTestcase();
 			return;


### PR DESCRIPTION
There is a mistake in current Chanta and Junchan yaku calculation. Sequences like 78999p appear among triples, sequences and pairs. When it happens, there will be 5 triples and sequences and 1 pairs, which misleads current Chanta and Junchan yaku calculation. In my patch, by checking the sequences' length, we can make sure there is no illegal sequences.